### PR TITLE
change circuit 321 from yellow to green

### DIFF
--- a/geojson/circuits.geojson
+++ b/geojson/circuits.geojson
@@ -45976,7 +45976,7 @@
       },
       "properties": {
         "id": 321,
-        "color": "yellow"
+        "color": "green"
       }
     }
   ]

--- a/geojson/problems.geojson
+++ b/geojson/problems.geojson
@@ -36184,11 +36184,11 @@
         "featured": false,
         "popularity": 0,
         "id": 29034,
-        "circuitColor": "yellow",
+        "circuitColor": "green",
         "circuitId": 321,
         "circuitNumber": "1",
-        "name": "Jaune 1 ",
-        "nameEn": "Yellow 1 "
+        "name": "Vert 1 ",
+        "nameEn": "Green 1 "
       }
     },
     {
@@ -42696,7 +42696,7 @@
         "featured": false,
         "popularity": 0,
         "id": 29035,
-        "circuitColor": "yellow",
+        "circuitColor": "green",
         "circuitId": 321,
         "circuitNumber": "2",
         "name": "Jaune 2 ",
@@ -47030,11 +47030,11 @@
         "featured": false,
         "popularity": 0,
         "id": 29036,
-        "circuitColor": "yellow",
+        "circuitColor": "green",
         "circuitId": 321,
         "circuitNumber": "3",
-        "name": "Jaune 3 ",
-        "nameEn": "Yellow 3 "
+        "name": "Vert 3 ",
+        "nameEn": "Green 3 "
       }
     },
     {
@@ -55126,11 +55126,11 @@
         "featured": false,
         "popularity": 0,
         "id": 29037,
-        "circuitColor": "yellow",
+        "circuitColor": "green",
         "circuitId": 321,
         "circuitNumber": "4",
-        "name": "Jaune 4 ",
-        "nameEn": "Yellow 4 "
+        "name": "Vert 4 ",
+        "nameEn": "Green 4 "
       }
     },
     {
@@ -386622,11 +386622,11 @@
         "featured": false,
         "popularity": 0,
         "id": 29038,
-        "circuitColor": "yellow",
+        "circuitColor": "green",
         "circuitId": 321,
         "circuitNumber": "5",
-        "name": "Jaune 5 ",
-        "nameEn": "Yellow 5 "
+        "name": "Vert 5 ",
+        "nameEn": "Green 5 "
       }
     },
     {


### PR DESCRIPTION
I was a little bit confused because in Roche aux Sabots there are now two yellow circuits ­­­– the green one for children aka https://bleau.info/sabots/circuit97.html  (which the app still lists als yellow, its internal ID is 321) and the "real"/new yellow circuit https://bleau.info/sabots/circuit358.html 

This PR changes the color of circuit 321 from yellow to green.

PS: It looks like circuit 269 is a equivalent of 321, but is missing it's problems and moved north (and is 50% to small) 
<img width="671" alt="image" src="https://github.com/user-attachments/assets/ad778f56-8d75-41e7-a35a-be7f435d797a" />
